### PR TITLE
Make auxo_state.description required

### DIFF
--- a/auxo/resource_state.go
+++ b/auxo/resource_state.go
@@ -33,7 +33,7 @@ func resourceState() *schema.Resource {
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "Description of the segment",
 			},
 			"protectsurface_id": {


### PR DESCRIPTION
The auxo_state.description field is required by the AUXO API.
This change will reflect this requirement in the provider.

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>