### PR TITLE
Change Makefile default target to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY=terraform-provider-${NAME}
 VERSION=0.0.5
 OS_ARCH=darwin_arm64 #amd64
 
-default: install
+default: build
 
 build:
 	go build -o ${BINARY}


### PR DESCRIPTION
The current Makefile has a default target of install. This will install the plugin into you users' terraform directory. This is a little uncommon, as usually `make` does not change anything outside the repo. That is what `make install` is used for.

This commit changes the default make target from `install` to `build`.