### PR TITLE
support for go-auxo v1.0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=on2itsecurity
 NAME=auxo
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.4
+VERSION=1.0.5
 OS_ARCH=darwin_arm64 #amd64
 
 default: build

--- a/auxo/datasource_protectsurface.go
+++ b/auxo/datasource_protectsurface.go
@@ -158,12 +158,12 @@ func (d *protectsurfaceDataSource) Schema(_ context.Context, _ datasource.Schema
 			"allow_flows_from_outside": schema.BoolAttribute{
 				Description:         "Allow flows from outside of the protectsurface coming in",
 				MarkdownDescription: "Allow flows from outside of the protectsurface coming in",
-				Computed:            true,
+				Optional:            true,
 			},
 			"allow_flows_to_outside": schema.BoolAttribute{
 				Description:         "Allow flows to go outside of the protectsurface",
 				MarkdownDescription: "Allow flows to go outside of the protectsurface",
-				Computed:            true,
+				Optional:            true,
 			},
 			"maturity_step1": schema.Int64Attribute{
 				Description:         "Maturity step 1",
@@ -262,8 +262,8 @@ func (d *protectsurfaceDataSource) Read(ctx context.Context, req datasource.Read
 			state.ComplianceTags = ct
 			state.CustomerLabels = cl
 			state.SOCTags = st
-			state.AllowFlowsFromOutside = types.BoolValue(ps.FlowsFromOutside.Allow)
-			state.AllowFlowsToOutside = types.BoolValue(ps.FlowsToOutside.Allow)
+			state.AllowFlowsFromOutside = types.BoolPointerValue(ps.FlowsFromOutside.Allow)
+			state.AllowFlowsToOutside = types.BoolPointerValue(ps.FlowsToOutside.Allow)
 			state.MaturityStep1 = types.Int64Value(int64(ps.Maturity.Step1))
 			state.MaturityStep2 = types.Int64Value(int64(ps.Maturity.Step2))
 			state.MaturityStep3 = types.Int64Value(int64(ps.Maturity.Step3))

--- a/auxo/resource_protectsurface.go
+++ b/auxo/resource_protectsurface.go
@@ -208,15 +208,11 @@ func (r *protectsurfaceResource) Schema(ctx context.Context, req resource.Schema
 				Description:         "Allow flows from outside of the protectsurface coming in",
 				MarkdownDescription: "Allow flows from outside of the protectsurface coming in",
 				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
 			},
 			"allow_flows_to_outside": schema.BoolAttribute{
 				Description:         "Allow flows to go outside of the protectsurface",
 				MarkdownDescription: "Allow flows to go outside of the protectsurface",
 				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
 			},
 			"maturity_step1": schema.Int64Attribute{
 				Description:         "Maturity step 1",
@@ -424,12 +420,8 @@ func resourceModelToProtectsurface(plan *protectsurfaceResourceModel, ctx contex
 		ComplianceTags:          ct,
 		CustomerLabels:          cl,
 		SocTags:                 st,
-		FlowsFromOutside: zerotrust.Flow{
-			Allow: plan.AllowFlowsFromOutside.ValueBool(),
-		},
-		FlowsToOutside: zerotrust.Flow{
-			Allow: plan.AllowFlowsToOutside.ValueBool(),
-		},
+		FlowsFromOutside:        zerotrust.Flow{Allow: plan.AllowFlowsFromOutside.ValueBoolPointer()},
+		FlowsToOutside:          zerotrust.Flow{Allow: plan.AllowFlowsToOutside.ValueBoolPointer()},
 		Maturity: zerotrust.Maturity{
 			Step1: int(plan.MaturityStep1.ValueInt64()),
 			Step2: int(plan.MaturityStep2.ValueInt64()),
@@ -474,8 +466,8 @@ func protectsurfaceToResourceModel(ps *zerotrust.ProtectSurface, ctx context.Con
 		ComplianceTags:        ct,
 		CustomerLabels:        cl,
 		SOCTags:               st,
-		AllowFlowsFromOutside: types.BoolValue(ps.FlowsFromOutside.Allow),
-		AllowFlowsToOutside:   types.BoolValue(ps.FlowsToOutside.Allow),
+		AllowFlowsFromOutside: types.BoolPointerValue(ps.FlowsFromOutside.Allow),
+		AllowFlowsToOutside:   types.BoolPointerValue(ps.FlowsToOutside.Allow),
 		MaturityStep1:         types.Int64Value(int64(ps.Maturity.Step1)),
 		MaturityStep2:         types.Int64Value(int64(ps.Maturity.Step2)),
 		MaturityStep3:         types.Int64Value(int64(ps.Maturity.Step3)),

--- a/auxo/utils.go
+++ b/auxo/utils.go
@@ -14,6 +14,11 @@ type apiError struct {
 	Message string `json:"error_message"`
 }
 
+// BoolPtr returns a pointer to a (given) bool
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 // getAPIError returns an apiError struct from a go-auxo error
 func getAPIError(err error) apiError {
 	var apiErr apiError

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     auxo = {
       source = "on2itsecurity/auxo"
-      version = "1.0.1"
+      version = "1.0.5"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/on2itsecurity/terraform-provider-auxo
 
-go 1.21
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.3
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/on2itsecurity/go-auxo v1.0.10
+	github.com/on2itsecurity/go-auxo v1.0.11
 )
 
 require (
@@ -30,9 +31,9 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/sys v0.24.0 // indirect
-	golang.org/x/text v0.17.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 // indirect
 	google.golang.org/grpc v1.67.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/on2itsecurity/go-auxo v1.0.10 h1:DgH8PEqLCDXBWF3iLt4Gf3Cg1yZ2xeqwJPmmeKtLY9c=
-github.com/on2itsecurity/go-auxo v1.0.10/go.mod h1:/bR2cwKeb76rMo2YEXdMhICye3jnk4BvajKCcWYg0hw=
+github.com/on2itsecurity/go-auxo v1.0.11 h1:JsDFqbZI1kUoMddF7vWsT0UAg5tKFcWglJrBrhUFU1c=
+github.com/on2itsecurity/go-auxo v1.0.11/go.mod h1:/iH0yAxzDwWyoJmAT9XgA1wZ8C1LqRdw+GBXfVB+ddc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -57,8 +57,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
-golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -66,10 +66,10 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
-golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
-golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142 h1:e7S5W7MGGLaSu8j3YjdezkZ+m1/Nm0uRVRMEMGk26Xs=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.67.1 h1:zWnc1Vrcno+lHZCOofnIMvycFcc0QRGIzm9dhnDX68E=


### PR DESCRIPTION
In go-auxo v1.0.11 the flow from & to outside field on a protect surface is being changed to a pointer, so it can withold 3 states. Unknown, False and True. Changed BoolValue to BoolPointerValue to support this.